### PR TITLE
feat/hashf

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+#
+# Local testing parameters - replace <variables> with correct values, do not commit!
+#
+STORAGEIP=<http://ipaddress>
+TEST_USERNAME=<username>
+TEST_PASSWORD=<password>

--- a/.env
+++ b/.env
@@ -1,6 +1,6 @@
 #
 # Local testing parameters - replace <variables> with correct values, do not commit!
 #
-STORAGEIP=<http://ipaddress>
+TEST_STORAGEIP=<http://ipaddress>
 TEST_USERNAME=<username>
 TEST_PASSWORD=<password>

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ This option runs the Go language test cases against a live storage system. Two s
 - Run `go test -v`
 
 Another option is to define environment variables, which take precedence over .env values
-- export TEST_STORAGEIP=http:/<ipaddress>
+- export TEST_STORAGEIP=http://<ipaddress>
 - export TEST_USERNAME=<username>
 - export TEST_USERNAME=<password>
 - Run `go test -v`

--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ You can also skip previous steps and just run tests with docker-compose:
 ```sh
 docker-compose up --build --abort-on-container-exit --exit-code-from tests
 ```
+
+## Test Using A Live System
+
+This option runs the Go language test cases against a live storage system. Two steps are required:
+- Update .env with the correct system IP Address and credentials
+- Run `go test -v`
+
+Another option is to define environment variables, which take precedence over .env values
+- export TEST_STORAGEIP=http:/<ipaddress>
+- export TEST_USERNAME=<username>
+- export TEST_USERNAME=<password>
+- Run `go test -v`
+- unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME

--- a/README.md
+++ b/README.md
@@ -33,6 +33,6 @@ This option runs the Go language test cases against a live storage system. Two s
 Another option is to define environment variables, which take precedence over .env values
 - export TEST_STORAGEIP=http://<ipaddress>
 - export TEST_USERNAME=<username>
-- export TEST_USERNAME=<password>
+- export TEST_PASSWORD=<password>
 - Run `go test -v`
 - unset TEST_STORAGEIP TEST_PASSWORD TEST_USERNAME

--- a/dothill.go
+++ b/dothill.go
@@ -18,7 +18,7 @@ type Client struct {
 	Addr       string
 	HTTPClient http.Client
 	Collector  *Collector
-	SessionKey string
+	sessionKey string
 }
 
 // NewClient : Creates a dothill client by setting up its HTTP client
@@ -60,7 +60,7 @@ func (client *Client) FormattedRequest(endpointFormat string, opts ...interface{
 func (client *Client) request(req *Request) (*Response, *ResponseStatus, error) {
 	isLoginReq := strings.Contains(req.Endpoint, "login")
 	if !isLoginReq {
-		if len(client.SessionKey) == 0 {
+		if len(client.sessionKey) == 0 {
 			klog.V(1).Info("no session key stored, authenticating before sending request")
 			err := client.Login()
 			if err != nil {

--- a/dothill.go
+++ b/dothill.go
@@ -18,7 +18,7 @@ type Client struct {
 	Addr       string
 	HTTPClient http.Client
 	Collector  *Collector
-	sessionKey string
+	SessionKey string
 }
 
 // NewClient : Creates a dothill client by setting up its HTTP client
@@ -60,7 +60,7 @@ func (client *Client) FormattedRequest(endpointFormat string, opts ...interface{
 func (client *Client) request(req *Request) (*Response, *ResponseStatus, error) {
 	isLoginReq := strings.Contains(req.Endpoint, "login")
 	if !isLoginReq {
-		if len(client.sessionKey) == 0 {
+		if len(client.SessionKey) == 0 {
 			klog.V(1).Info("no session key stored, authenticating before sending request")
 			err := client.Login()
 			if err != nil {

--- a/endpoints.go
+++ b/endpoints.go
@@ -2,38 +2,21 @@ package dothill
 
 import (
 	"crypto/md5"
-	"crypto/sha256"
 	"fmt"
 	"strings"
 )
 
 // Login : Called automatically, may be called manually if credentials changed
-func (client *Client) Login(hashf ...string) error {
+func (client *Client) Login() error {
 	userpass := fmt.Sprintf("%s_%s", client.Username, client.Password)
-
-	var hashmethod string = "md5"
-	if len(hashf) > 0 {
-		hashmethod = hashf[0]
-	}
-
-	var hash string
-	if hashmethod == "md5" {
-		hash = fmt.Sprintf("%x", md5.Sum([]byte(userpass)))
-	} else if hashmethod == "sha256" {
-		hasher := sha256.New()
-		hasher.Write([]byte(userpass))
-		hash = fmt.Sprintf("%x", hasher.Sum(nil))
-	} else {
-		return fmt.Errorf("Login: hash function (%s) not supported, try: md5, sha256", hashmethod)
-	}
-
+	hash := fmt.Sprintf("%x", md5.Sum([]byte(userpass)))
 	res, _, err := client.FormattedRequest("/login/%s", hash)
 
 	if err != nil {
 		return err
 	}
 
-	client.SessionKey = res.ObjectsMap["status"].PropertiesMap["response"].Data
+	client.sessionKey = res.ObjectsMap["status"].PropertiesMap["response"].Data
 	return nil
 }
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/enix/dothill-api-go
 go 1.12
 
 require (
+	github.com/joho/godotenv v1.3.0
 	github.com/onsi/gomega v1.10.5
 	github.com/prometheus/client_golang v1.10.0
 	k8s.io/klog v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,7 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/franela/goblin v0.0.0-20200105215937-c9ffbefa60db/go.mod h1:7dvUGVsVBjqR7JHJk0brhHOZYGmfBYOrK0ZhYMEtBr4=
 github.com/franela/goreq v0.0.0-20171204163338-bcd34c9993f8/go.mod h1:ZhphrRTfi2rbfLwlschooIH4+wKKDR4Pdxhh+TRoA20=
+github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-kit/kit v0.8.0/go.mod h1:xBxKIO96dXMWWy0MnWVtmwkA9/13aqxPnvrjFYMA2as=
@@ -89,6 +90,7 @@ github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5a
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.5.4 h1:L8R9j+yAqZuZjsqh/z+F1NCffTKKLShY6zXTItVIZ8M=
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
@@ -126,6 +128,8 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
+github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.6/go.mod h1:+SdeFBvtyEkXs7REEP0seUULqWtbJapLOCVDaaPEHmU=
@@ -140,8 +144,10 @@ github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+o
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
+github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/lightstep/lightstep-tracer-common/golang/gogo v0.0.0-20190605223551-bc2310a04743/go.mod h1:qklhhLq1aX+mtWk9cPHPzaBjWImj5ULL6C7HFJtXQMM=
 github.com/lightstep/lightstep-tracer-go v0.18.1/go.mod h1:jlF1pusYV4pidLvZ+XD0UBX0ZE6WURAspgAczcDHrL4=
@@ -173,12 +179,14 @@ github.com/nats-io/nats.go v1.9.1/go.mod h1:ZjDU1L/7fJ09jvUSRVBR2e7+RnLiiIQyqyzE
 github.com/nats-io/nkeys v0.1.0/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nkeys v0.1.3/go.mod h1:xpnFELMwJABBLVhffcfd1MZx6VsNRFpEugbxziKVo7w=
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
+github.com/nxadm/tail v1.4.4 h1:DQuhQpB1tVlglWS2hLQ5OV6B5r8aGxSrPc5Qo6uTN78=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
+github.com/onsi/ginkgo v1.12.1 h1:mFwc4LvZ0xpSvDZ3E+k8Yte0hLOMxXUlP+yXtJqkYfQ=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
@@ -362,6 +370,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/tools v0.0.0-20200103221440-774c71fcf114/go.mod h1:TB2adYChydJhpapKDTa4BR/hXlZSLoq2Wpct/0txZ28=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
@@ -391,12 +400,14 @@ google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/errgo.v2 v2.1.0/go.mod h1:hNsd1EY+bozCKY1Ytp96fpM3vjJbqLJn88ws8XvfDNI=
 gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMys=
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
+gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=

--- a/main_test.go
+++ b/main_test.go
@@ -68,7 +68,7 @@ func TestReLoginFailed(t *testing.T) {
 	_, status, err := wrongClient.Request("/status/code/1")
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	g.Expect(status.Response).To(Equal("request failed"))
+	g.Expect(status.Response).To(Equal("re-login failed"))
 }
 
 func TestInvalidURL(t *testing.T) {
@@ -86,7 +86,7 @@ func TestInvalidXML(t *testing.T) {
 
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	g.Expect(status.Response).To(Equal("request failed"))
+	g.Expect(status.Response).To(Equal("corrupted response"))
 }
 
 func TestStatusCodeNotZero(t *testing.T) {
@@ -94,5 +94,5 @@ func TestStatusCodeNotZero(t *testing.T) {
 	_, status, err := client.Request("/status/code/1")
 
 	g.Expect(err).NotTo(BeNil())
-	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
+	g.Expect(status.ResponseTypeNumeric).To(Equal(1))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -80,7 +80,7 @@ func TestReLoginFailed(t *testing.T) {
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
 	// This test returns one of two different values based on the  API version, either: 'request failed' or 'Invalid sessionkey'
-	g.Expect(status.Response).Should(BeElementOf([]string{"request failed", "Invalid sessionkey"}))
+	g.Expect(status.Response).Should(BeElementOf([]string{"re-login failed", "request failed", "Invalid sessionkey"}))
 }
 
 func TestInvalidURL(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -5,19 +5,25 @@ import (
 	"os"
 	"testing"
 
+	dothill "github.com/enix/dothill-api-go"
+
+	"github.com/joho/godotenv"
 	. "github.com/onsi/gomega"
 )
 
-var client = NewClient()
+var client *dothill.Client = dothill.NewClient()
 
 func init() {
-	client.Addr = "http://localhost:8080"
-	client.Username = "manage"
-	client.Password = "!manage"
-
-	if endpoint := os.Getenv("API_ENDPOINT"); endpoint != "" {
-		client.Addr = endpoint
+	settingsfile := ".env"
+	err := godotenv.Load(settingsfile)
+	if err != nil {
+		fmt.Printf("Error loading file (%s), error: %v\n", settingsfile, err)
+		return
 	}
+
+	client.Addr = os.Getenv("STORAGEIP")
+	client.Username = os.Getenv("TEST_USERNAME")
+	client.Password = os.Getenv("TEST_PASSWORD")
 }
 
 func assert(t *testing.T, cond bool, msg string) {
@@ -28,13 +34,17 @@ func assert(t *testing.T, cond bool, msg string) {
 	}
 }
 
-func TestLogin(t *testing.T) {
-	g := NewGomegaWithT(t)
+func TestLoginG(t *testing.T) {
+	g := NewWithT(t)
 	g.Expect(client.Login()).To(BeNil())
+}
+func TestLoginI(t *testing.T) {
+	g := NewWithT(t)
+	g.Expect(client.Login("sha256")).To(BeNil())
 }
 
 func TestLoginFailed(t *testing.T) {
-	var wrongClient = NewClient()
+	var wrongClient = dothill.NewClient()
 	wrongClient.Addr = client.Addr
 	wrongClient.Username = client.Username
 	wrongClient.Password = "wrongpassword"
@@ -44,7 +54,7 @@ func TestLoginFailed(t *testing.T) {
 }
 
 func TestReLoginFailed(t *testing.T) {
-	var wrongClient = NewClient()
+	var wrongClient = dothill.NewClient()
 	wrongClient.Addr = client.Addr
 	wrongClient.Username = client.Username
 	wrongClient.Password = client.Password
@@ -53,12 +63,12 @@ func TestReLoginFailed(t *testing.T) {
 	g.Expect(wrongClient.Login()).To(BeNil())
 
 	wrongClient.Password = "wrongpassword"
-	wrongClient.sessionKey = "outdated-session-key"
+	wrongClient.SessionKey = "outdated-session-key"
 
 	_, status, err := wrongClient.Request("/status/code/1")
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	g.Expect(status.Response).To(Equal("re-login failed"))
+	g.Expect(status.Response).To(Equal("request failed"))
 }
 
 func TestInvalidURL(t *testing.T) {
@@ -76,7 +86,7 @@ func TestInvalidXML(t *testing.T) {
 
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	g.Expect(status.Response).To(Equal("corrupted response"))
+	g.Expect(status.Response).To(Equal("request failed"))
 }
 
 func TestStatusCodeNotZero(t *testing.T) {
@@ -84,5 +94,5 @@ func TestStatusCodeNotZero(t *testing.T) {
 	_, status, err := client.Request("/status/code/1")
 
 	g.Expect(err).NotTo(BeNil())
-	g.Expect(status.ResponseTypeNumeric).To(Equal(1))
+	g.Expect(status.ResponseTypeNumeric).To(Equal(0))
 }

--- a/main_test.go
+++ b/main_test.go
@@ -79,7 +79,7 @@ func TestReLoginFailed(t *testing.T) {
 	_, status, err := wrongClient.Request("/status/code/1")
 	g.Expect(err).NotTo(BeNil())
 	g.Expect(status.ResponseType).To(Equal("Error"))
-	// This test returns one of two different values based on the  API version, either: 'request failed' or 'Invalid sessionkey'
+	// This test returns one of three different values based on the  API version.
 	g.Expect(status.Response).Should(BeElementOf([]string{"re-login failed", "request failed", "Invalid sessionkey"}))
 }
 

--- a/request.go
+++ b/request.go
@@ -19,7 +19,6 @@ func (req *Request) execute(client *Client) ([]byte, int, error) {
 		return nil, 0, err
 	}
 
-	httpReq.SetBasicAuth(client.Username, client.Password)
 	httpReq.Header.Set("sessionKey", client.SessionKey)
 	res, err := client.HTTPClient.Do(httpReq)
 	if err != nil {

--- a/request.go
+++ b/request.go
@@ -19,7 +19,8 @@ func (req *Request) execute(client *Client) ([]byte, int, error) {
 		return nil, 0, err
 	}
 
-	httpReq.Header.Set("sessionKey", client.sessionKey)
+	httpReq.SetBasicAuth(client.Username, client.Password)
+	httpReq.Header.Set("sessionKey", client.SessionKey)
 	res, err := client.HTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, 0, err

--- a/request.go
+++ b/request.go
@@ -19,7 +19,8 @@ func (req *Request) execute(client *Client) ([]byte, int, error) {
 		return nil, 0, err
 	}
 
-	httpReq.Header.Set("sessionKey", client.SessionKey)
+	httpReq.Header.Set("sessionKey", client.sessionKey)
+	httpReq.SetBasicAuth(client.Username, client.Password)
 	res, err := client.HTTPClient.Do(httpReq)
 	if err != nil {
 		return nil, 0, err


### PR DESCRIPTION
- Reverting to minimal changes to support older and newer storage API versions
- Corrected the main_tests to use either env variables or the .env file, this will allow it to work for testing multiple appliances
- Removed the change to make sessionKey public, it really was not required and felt it best to remove and address the review point.
- Attempted to correct the commit message to match the conventional commit spec. Client.Login() was reverted and not changed.
- Added BasicAuth() so that the login with an md5 hash will work on older and new API versions. Tested against older and new revisions of the API.
- Corrected the main_test.go to work with the two strings returned by older and new API versions.
- Corrected or reverted other test file changes.