### PR TITLE
fix(client): handle additional session timeout value of 403

### DIFF
--- a/dothill.go
+++ b/dothill.go
@@ -95,7 +95,7 @@ func (client *Client) request(req *Request) (*Response, *ResponseStatus, error) 
 	}
 
 	raw, code, err := req.execute(client)
-	if code == 401 && !isLoginReq {
+	if (code == 401 || code == 403) && !isLoginReq {
 		klog.V(1).Info("session key may have expired, trying to re-login")
 		err = client.Login()
 		if err != nil {


### PR DESCRIPTION
A small change to handle the HTTP status of 403 (Forbidden) returned by newer versions of the storage array API. This allows the driver to reestablish a session after the session times out (default is 30 minutes).